### PR TITLE
Rewrote utils.toJSON to handle relations recursively

### DIFF
--- a/src/bookshelf/extras.ts
+++ b/src/bookshelf/extras.ts
@@ -13,10 +13,33 @@ export interface Model extends BModel<any> {
   relations:  RelationsObject;
 }
 
+/**
+ * Determine whether a Bookshelf object is a Model.
+ * @param data
+ * @returns {boolean}
+ */
+export function isModel(data: Data): data is Model {
+  if (!data) return false;
+  // Duck-typing
+  return (<Model> data).attributes !== undefined;
+}
+
 // Using internally defined properties
 export interface Collection extends BCollection<any> {
   models: Model[];
   length: number;
 }
+
+/**
+ * Determine whether a Bookshelf object is a Collection.
+ * @param data
+ * @returns {boolean}
+ */
+export function isCollection(data: Data): data is Collection {
+  if (!data) return false;
+  // Duck-typing
+  return (<Collection> data).models !== undefined;
+}
+
 
 export type Data = Model | Collection;

--- a/src/bookshelf/extras.ts
+++ b/src/bookshelf/extras.ts
@@ -19,9 +19,11 @@ export interface Model extends BModel<any> {
  * @returns {boolean}
  */
 export function isModel(data: Data): data is Model {
-  if (!data) return false;
-  // Duck-typing
-  return (<Model> data).attributes !== undefined;
+  if (!data) {
+    return false;
+  } else {
+    return ! isCollection(data);
+  }
 }
 
 // Using internally defined properties
@@ -36,9 +38,12 @@ export interface Collection extends BCollection<any> {
  * @returns {boolean}
  */
 export function isCollection(data: Data): data is Collection {
-  if (!data) return false;
-  // Duck-typing
-  return (<Collection> data).models !== undefined;
+  if (!data) {
+    return false;
+  } else {
+    // Duck-typing
+    return (<Collection> data).models !== undefined;
+  }
 }
 
 

--- a/src/bookshelf/links.ts
+++ b/src/bookshelf/links.ts
@@ -5,7 +5,7 @@ import * as inflection from 'inflection';
 import * as Qs from 'qs';
 import * as Serializer from 'jsonapi-serializer';
 
-import {Data, Model, Collection} from './extras';
+import {Data, Model, isModel, Collection, isCollection} from './extras';
 import * as I from '../interfaces.d';
 import * as utils from './utils';
 
@@ -113,13 +113,10 @@ export function buildSelf(baseUrl: string, modelType: string, relatedType: strin
         inflection.pluralize(type);
 
       // If a model
-      if (utils.isModel(current)) {
-        let model: Model = <Model> current;
-
-        return link + '/' + model.id; // TODO ADD QUERY PARAMS AND PAGINATION
-
+      if (isModel(current)) {
+        return link + '/' + current.id; // TODO ADD QUERY PARAMS AND PAGINATION
       // If collection
-      } else if (utils.isCollection(current)) {
+      } else if (isCollection(current)) {
         return link;
       }
     }

--- a/src/bookshelf/mapper.ts
+++ b/src/bookshelf/mapper.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import * as Serializer from 'jsonapi-serializer';
 import * as tc from 'type-check';
 
-import {Data, Model, Collection} from './extras';
+import {Data, Model, isModel, Collection, isCollection} from './extras';
 import * as I from '../interfaces.d';
 import * as links from './links';
 import * as utils from './utils';
@@ -45,18 +45,16 @@ export default class Bookshelf implements I.Mapper {
     template.dataLinks = links.buildSelf(self.baseUrl, type, null, bookshelfOptions.query);
 
     // Serializer process for a Model
-    if (utils.isModel(data)) {
-      let model: Model = <Model> data;
-
+    if (isModel(data)) {
       // Add list of valid attributes
-      template.attributes = utils.getDataAttributesList(model);
+      template.attributes = utils.getDataAttributesList(data);
 
       // Provide support for withRelated option TODO WARNING DEPRECATED. To be deleted on next major version
       if (bookshelfOptions.includeRelations) bookshelfOptions.relations = bookshelfOptions.includeRelations;
 
       // Add relations (only if permitted)
       if (bookshelfOptions.relations) {
-        _.forOwn(model.relations, function (relModel: Model, relName: string): void {
+        _.forOwn(data.relations, function (relModel: Model, relName: string): void {
 
           // Skip if the relation is not permitted
           if (bookshelfOptions.relations === false ||
@@ -85,9 +83,9 @@ export default class Bookshelf implements I.Mapper {
       }
 
       // Serializer process for a Collection
-    } else if (utils.isCollection(data)) {
+    } else if (isCollection(data)) {
 
-      let model: Model = (<Collection> data).first();
+      let model: Model = data.first();
 
       if (!_.isUndefined(model)) {
 

--- a/src/bookshelf/utils.ts
+++ b/src/bookshelf/utils.ts
@@ -95,11 +95,9 @@ export function toJSON(data: Data): any {
 
   // Collection case
   } else if (isCollection(data)) {
-    let collection = data as Collection;
-
     // Run a recursive toJSON on each model of the collection
-    for (let index: number = 0; index < collection.length; ++index) {
-      json[index] = toJSON(collection.models[index]);
+    for (let index: number = 0; index < data.length; ++index) {
+      json[index] = toJSON(data.models[index]);
     }
   }
 

--- a/src/bookshelf/utils.ts
+++ b/src/bookshelf/utils.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {Data, Model, Collection} from './extras';
+import {Data, Model, isModel, Collection, isCollection} from './extras';
 import * as _ from 'lodash';
 import * as Serializer from 'jsonapi-serializer';
 import * as inflection from 'inflection';
@@ -135,26 +135,4 @@ export function toJSON(data: any): any {
   }
 
   return json;
-}
-
-/**
- * Determine whether a Bookshelf object is a Model.
- * @param data
- * @returns {boolean}
- */
-export function isModel(data: Data): boolean {
-  if (!data) return false;
-  // Is-not-a-Duck-typing
-  return (<Collection> data).models === undefined;
-}
-
-/**
- * Determine whether a Bookshelf object is a Collection.
- * @param data
- * @returns {boolean}
- */
-export function isCollection(data: Data): boolean {
-  if (!data) return false;
-  // Duck-typing
-  return (<Collection> data).models !== undefined;
 }


### PR DESCRIPTION
The previous implementation of `utils.toJSON` _cared_ about two levels deep of relations, handling the case in which a relation is _to-many_ incorrectly.

Now the function uses only the current model level and is called recursively on the relations of it. In the case of a collection being passed, it calls recursively on each model of the collection.