### PR TITLE
Support deeply nested relations when building template

### DIFF
--- a/src/bookshelf/mapper.ts
+++ b/src/bookshelf/mapper.ts
@@ -34,7 +34,7 @@ export default class Bookshelf implements I.Mapper {
    * @param bookshelfOptions
    * @param template
    */
-  mapRelations(model: any, type: string, bookshelfOptions: I.BookshelfOptions = {relations: true}, template?: ISerializerOptions): any {
+  mapRelations(model: Model, type: string, bookshelfOptions: I.BookshelfOptions = {relations: true}, template?: ISerializerOptions): void {
     let self: this = this;
     _.forOwn(model.relations, function (relModel: Model, relName: string): void {
 


### PR DESCRIPTION
Currently the serialiser only supports 2-deep relations. This PR adds support for unlimited nesting of relations. The data is already in the JSON since the toJSON in the util class in recursive. This PR makes the serialiser also recursive.