### PR TITLE
Add a test case for nested has-many relations (see #50)

### DIFF
--- a/spec/bookshelf-spec.ts
+++ b/spec/bookshelf-spec.ts
@@ -1103,7 +1103,7 @@ describe('Bookshelf relations', () => {
           ],
           data: [{
               relationships: {
-                  'related-model': {
+                  'related-models': {
                       data: [
                         {
                             type: 'related-models',

--- a/spec/bookshelf-spec.ts
+++ b/spec/bookshelf-spec.ts
@@ -1047,7 +1047,7 @@ describe('Bookshelf relations', () => {
 
   });
 
-  fit('should support including nested has-many relationships', () => {
+  it('should support including nested has-many relationships', () => {
     let model1: Model = bookshelf.Model.forge<any>({id: '5', attr: 'value'});
     let model2: Model = bookshelf.Model.forge<any>({id: '6', attr: 'value'});
 

--- a/spec/bookshelf-spec.ts
+++ b/spec/bookshelf-spec.ts
@@ -1047,6 +1047,77 @@ describe('Bookshelf relations', () => {
 
   });
 
+  fit('should support including nested has-many relationships', () => {
+    let model1: Model = bookshelf.Model.forge<any>({id: '5', attr: 'value'});
+    let model2: Model = bookshelf.Model.forge<any>({id: '6', attr: 'value'});
+
+
+    (<any> model1).relations['related-models'] = bookshelf.Collection.forge<any>([model2]);
+    (<any> model2).relations['nested-related-models'] = bookshelf.Collection.forge<any>([
+        bookshelf.Model.forge<any>({id: '10', attr: 'value'}),
+        bookshelf.Model.forge<any>({id: '11', attr: 'value'})
+    ]);
+
+    let collection: Collection = bookshelf.Collection.forge<any>([model1]);
+
+    let result: any = mapper.map(collection, 'models');
+
+    let expected: any = {
+          included: [
+              {
+                  id: '6',
+                  type: 'related-models',
+                  attributes: {
+                      attr: 'value'
+                  },
+                  relationships: {
+                      'nested-related-models': {
+                          data: [{
+                              type: 'nested-related-models',
+                              id: '10'
+                          }, {
+                                  type: 'nested-related-models',
+                                  id: '11'
+                              }],
+                          links: {
+                              self: `${domain}/related-models/6/relationships/nested-related-models`,
+                              related: `${domain}/related-models/6/nested-related-models`
+                          }
+                      }
+                  }
+              },
+              {
+                  id: '10',
+                  type: 'nested-related-models',
+                  attributes: {
+                      attr: 'value'
+                  }
+              },
+              {
+                  id: '11',
+                  type: 'nested-related-models',
+                  attributes: {
+                      attr: 'value'
+                  }
+              }
+          ],
+          data: [{
+              relationships: {
+                  'related-model': {
+                      data: [
+                        {
+                            type: 'related-models',
+                            id: '6'
+                        }
+                      ]
+                  }
+              }
+          }]
+      };
+
+    expect(_.matches(expected)(result)).toBe(true);
+  });
+
   it('should support including nested relationships when acting on a collection', () => {
 
     let model1: Model = bookshelf.Model.forge<any>({id: '5', attr: 'value'});


### PR DESCRIPTION
Here is a test case reflecting issue #50. The case is similar to [this one](https://github.com/scoutforpets/jsonapi-mapper/blob/master/spec/bookshelf-spec.ts#L1050), but having a `Collection` as its relation.

```typescript
(<any> model1).relations['related-models'] = bookshelf.Collection.forge<any>([model2]);
```

I'm new to TypeScript so please correct me if I miss something in this PR.