### PR TITLE
ability to include/exclude relation data in payload (fixes #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ mapper#map(data, type, mapperOptions)
 - `data` _(object)_: The data object from Bookshelf (either a Model or a Collection) to be serialized.
 - `type` _(string)_: The type of the resource being returned. For example, if you passed in an `Appointment` model, your `type` might be `appointment`.
 - _(optional)_ `mapperOptions` _(object)_:
-  - _(optional)_ `relations` _(boolean | string[])_: Flag to enable (`true`) or disable (`false`) serializing of related models on the response. Alternatively, you can provide a string array to indicate the specific relations you want to serialize. Defaults to `true`.
+  - _(optional)_ `relations` _(boolean | object)_: Flag to enable (`true`) or disable (`false`) serializing of related models on the response. Alternatively, you can provide an object containing the following options:
+    - `included` (default: `true`) - includes relation data in the response
+    - `fields` _array_ - an array of relation names that should be included in the response
   - _(optional)_ `relationTypes` _(object | function)_: To specify any relation whose type should not be a pluralization of it's name. If the type to use returned is a _falsy_ value for a relation name, that name is automatically pluralized. Pluralizes all relation names and passed type by default.
     - _object option_: Objects should have the structure `{'relationName': 'typeToUse'}` (e.g. `{'best-friend': 'people'}`).
     - _function option_: Functions should expect a `string` as input (the relation name) and output a `string` (the type to use) (e.g. `(x) => x + '_resources'`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-mapper",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "JSON API-Compliant Serialization for your ORM",
   "main": "es5/src/mapper.js",
   "scripts": {

--- a/spec/bookshelf-spec.ts
+++ b/spec/bookshelf-spec.ts
@@ -113,7 +113,7 @@ describe('Bookshelf Adapter', () => {
     expect(_.matches(expected)(result)).toBe(true);
   });
 
-  it('should inlcude a repeated model only once in the included array', () => {
+  it('should include a repeated model only once in the included array', () => {
     let model: any = bookshelf.Model.forge({
       id : 5,
       name: 'A test model',
@@ -1378,7 +1378,7 @@ describe('Bookshelf relations', () => {
       bookshelf.Model.forge<any>({id: '11', attr2: 'value21'})
     ]);
 
-    let result1: any = mapper.map(model, 'models', {relations: true});
+    let result1: any = mapper.map(model, 'models', {relations: { included: true }});
     let result2: any = mapper.map(model, 'models', {relations: false});
 
     let expected1: any = {
@@ -1411,7 +1411,8 @@ describe('Bookshelf relations', () => {
     (model as any).relations['related-one'] = bookshelf.Model.forge<any>({id: '10', attr1: 'value1'});
     (model as any).relations['related-two'] = bookshelf.Model.forge<any>({id: '20', attr2: 'value2'});
 
-    let result: any = mapper.map(model, 'models', {relations: ['related-two']});
+    let result: any = mapper.map(model, 'models', {relations: { fields: ['related-two'], included: true }});
+    let result2: any = mapper.map(model, 'models', {relations: { fields: ['related-two'], included: false }});
 
     let expected: any = {
       included: [
@@ -1426,6 +1427,9 @@ describe('Bookshelf relations', () => {
     };
 
     expect(_.matches(expected)(result)).toBe(true);
+
+    expect(_.has(result2, 'data.relationships.related-two')).toBe(true);
+    expect(_.has(result2, 'included')).toBe(false);
   });
 
   it('should give an option to sepcify relation types with an object', () => {
@@ -1520,6 +1524,46 @@ describe('Bookshelf relations', () => {
 
   it('should give an API to merge relations attributes', () => {
     pending('Not targeted for release 1.x');
+  });
+
+  it('should give an option to include relations', () => {
+    let model: Model = bookshelf.Model.forge<any>({id: '5', atrr: 'value'});
+    (model as any).relations['related-models'] = bookshelf.Collection.forge<any>([
+      bookshelf.Model.forge<any>({id: '10', attr2: 'value20'}),
+      bookshelf.Model.forge<any>({id: '11', attr2: 'value21'})
+    ]);
+
+    let result1: any = mapper.map(model, 'models', {relations: { included: true }});
+    let result2: any = mapper.map(model, 'models', {relations: { included: false }});
+    let result3: any = mapper.map(model, 'models', {relations: false});
+
+    let expected1: any = {
+      included: [
+        {
+          id: '10',
+          type: 'related-models',
+          attributes: {
+            attr2: 'value20'
+          }
+        },
+        {
+          id: '11',
+          type: 'related-models',
+          attributes: {
+            attr2: 'value21'
+          }
+        }
+      ]
+    };
+
+    expect(_.matches(expected1)(result1)).toBe(true);
+    expect(_.has(result1, 'data.relationships.related-models')).toBe(true);
+
+    expect(_.has(result2, 'data.relationships.related-models')).toBe(true);
+    expect(_.has(result2, 'included')).toBe(false);
+
+    expect(_.has(result3, 'data.relationships.related-models')).toBe(false);
+    expect(_.has(result3, 'included')).toBe(false);
   });
 });
 

--- a/src/bookshelf/index.ts
+++ b/src/bookshelf/index.ts
@@ -30,7 +30,7 @@ export default class Bookshelf implements Mapper {
     let linkOpts: LinkOpts = { baseUrl: this.baseUrl, type, pag: bookOpts.pagination };
 
     // Set default values for the options
-    bookOpts = assign({relations: true, enableLinks: true}, bookOpts);
+    bookOpts = assign({relations: { included: true }, enableLinks: true}, bookOpts);
 
     let info: Information = { bookOpts, linkOpts };
 

--- a/src/bookshelf/index.ts
+++ b/src/bookshelf/index.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { assign } from 'lodash';
+import { assign, defaultsDeep } from 'lodash';
 import { SerialOpts, Serializer } from 'jsonapi-serializer';
 import { Mapper } from '../interfaces';
 import { Data, BookOpts } from './extras';
@@ -30,7 +30,7 @@ export default class Bookshelf implements Mapper {
     let linkOpts: LinkOpts = { baseUrl: this.baseUrl, type, pag: bookOpts.pagination };
 
     // Set default values for the options
-    bookOpts = assign({relations: { included: true }, enableLinks: true}, bookOpts);
+    defaultsDeep(bookOpts, {relations: { included: true }, enableLinks: true})
 
     let info: Information = { bookOpts, linkOpts };
 

--- a/src/bookshelf/utils.ts
+++ b/src/bookshelf/utils.ts
@@ -11,6 +11,7 @@ import { typeCheck } from 'type-check';
 
 import { SerialOpts } from 'jsonapi-serializer';
 import { LinkOpts } from '../links';
+import { RelationOpts } from '../relations';
 import { topLinks, dataLinks, relationshipLinks, includedLinks } from './links';
 import { BookOpts, Data, Model, isModel, isCollection } from './extras';
 
@@ -45,7 +46,8 @@ export function processData(info: Information, data: Data): SerialOpts {
  */
 function processSample(info: Information, sample: Model): SerialOpts {
   let { bookOpts, linkOpts }: Information = info;
-  let { enableLinks }: BookOpts = bookOpts;
+  let { enableLinks, relations }: BookOpts = bookOpts;
+  let { included }: RelationOpts = relations;
 
   let template: SerialOpts = {};
 
@@ -64,6 +66,11 @@ function processSample(info: Information, sample: Model): SerialOpts {
     if (enableLinks) {
       relTemplate.relationshipLinks = relationshipLinks(linkOpts, relName);
       relTemplate.includedLinks = includedLinks(relLinkOpts);
+    }
+
+    // Include links as compound document
+    if (!included) {
+        relTemplate.included = false;
     }
 
     template[relName] = relTemplate;
@@ -123,10 +130,11 @@ function getAttrsList(data: Model): any {
  */
 function relationAllowed(bookOpts: BookOpts, relName: string): boolean {
   let { relations }: BookOpts = bookOpts;
+  let { fields }: RelationOpts = relations;
 
   return relations === true ||
-    (typeCheck('[String]', relations) &&
-      (relations as string[]).some((rel: string) => rel === relName));
+         relations instanceof Object ||
+         (fields instanceof Object && (fields as string[]).some((rel: string) => rel === relName));
 }
 
 /**

--- a/src/bookshelf/utils.ts
+++ b/src/bookshelf/utils.ts
@@ -69,9 +69,7 @@ function processSample(info: Information, sample: Model): SerialOpts {
     }
 
     // Include links as compound document
-    if (!included) {
-        relTemplate.included = false;
-    }
+    relTemplate.included = included;
 
     template[relName] = relTemplate;
     template.attributes.push(relName);
@@ -134,7 +132,7 @@ function relationAllowed(bookOpts: BookOpts, relName: string): boolean {
 
   return relations === true ||
          relations instanceof Object ||
-         (fields instanceof Object && (fields as string[]).some((rel: string) => rel === relName));
+         (fields instanceof Array && fields.some((rel: string) => rel === relName));
 }
 
 /**

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,5 +1,5 @@
 import { PagOpts, QueryOpts } from './links';
-import { RelationTypeOpt } from './relations';
+import { RelationTypeOpt, RelationOpts } from './relations';
 
 //// GENERAL INTERFACES FOR MAPPERS
 
@@ -11,7 +11,7 @@ export interface Mapper {
 // Mapper Options
 export interface MapOpts {
   // Relations-related
-  relations?: boolean | string[];
+  relations?: boolean | RelationOpts;
   relationTypes?: RelationTypeOpt;
 
   // Links-related

--- a/src/relations.d.ts
+++ b/src/relations.d.ts
@@ -14,3 +14,8 @@ export type RelationTypeFunction = (attribute: string) => string;
  * The relationTypes option can be a function or an object
  */
 export type RelationTypeOpt = RelationTypeMap | RelationTypeFunction;
+
+export interface RelationOpts {
+    included?: boolean,
+    fields?: string[]
+}


### PR DESCRIPTION
This PR fixes #63 by allowing an `included` attribute to be specified as part of the `relations` option. Previously, the `relations` option was either a boolean or an array of strings. This has now been changed to either a boolean or an object containing options that determine how a relationship is processed.

The array of relation names has now been moved into a `fields` property. Example:

```js
relations: {
  fields: ['rel1', 'rel2']
}
```

The new syntax also allows for an `included` option to determine whether the relation data is included as a compound document, which has been the default thus far. Setting `included: false` will not include the actual relation data in the payload.

Scenarios:

```js
relations : true // all in, to maintain the current behaviour
relations : false // nothing
relations : { included: true } // relation data included in payload
relations : { included: false } // relations defined, but data not included in payload
```