### PR TITLE
Handle idAttribute as an array

### DIFF
--- a/src/bookshelf/extras.ts
+++ b/src/bookshelf/extras.ts
@@ -35,6 +35,11 @@ export interface Attributes {
  */
 export interface Model extends BModel<any> {
   id: any;
+
+  // TODO: PR to fix Bookshelf types
+  // idAttribute?: string | string[];
+  idAttribute: any;
+
   attributes: Attributes;
   relations: RelationsObject;
 }


### PR DESCRIPTION
The idea of this PR is to handle `idAttribute` values from Bookshelf that are arrays, [these are a little bit supported](https://github.com/tgriesser/bookshelf/issues/865) and my team is currently using them for some stuff.

Thought we could add it even though it's not official.

******

What should we return for `id`? I set it to return the a string of the ids joined by commas `,`, but could be a differently formatted string.

NOTE: JSONAPI specifies that [`id` **MUST** be a string](http://jsonapi.org/format/#document-resource-object-identification).