### PR TITLE
Update @types/bookshelf to v0.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "es5"
   ],
   "dependencies": {
-    "@types/bookshelf": "^0.8.35",
+    "@types/bookshelf": "^0.9.6",
     "inflection": "1.12.0",
     "jsonapi-serializer": "^3.3.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Will fix this error. I'm not sure if its a problem with npm `5.3.0`

```
node_modules/@types/bookshelf/index.d.ts(41,17): error TS2559: Type 'ModelBase<T>' has no properties in common with type 'IModelBase'.
```