### PR TITLE
Make id always be a string

### DIFF
--- a/spec/bookshelf-spec.ts
+++ b/spec/bookshelf-spec.ts
@@ -696,6 +696,47 @@ describe('Bookshelf Adapter', () => {
 
     expect(_.matches(expected)(result)).toBe(true);
   });
+
+  describe('should serialize id as string', () => {
+
+    it('for basic model', () => {
+      let model: Model = bookshelf.Model.forge<any>({ id: 5 });
+
+      let result: any = mapper.map(model, 'models');
+
+      expect(result.data.id).toBe('5');
+      expect(typeof result.data.id).toBe('string');
+    });
+
+    it('for collection', () => {
+      let elements: Model[] = _.times(5, (num) => {
+        return bookshelf.Model.forge<any>({id: num, attr: 'value' + num});
+      });
+
+      let collection: Collection = bookshelf.Collection.forge<any>(elements);
+
+      let result: any = mapper.map(collection, 'models');
+
+      _.times(5, (num) => {
+        expect(result.data[num].id).toBe(num.toString());
+        expect(typeof result.data[num].id).toBe('string');
+      });
+    });
+
+    it('for relationships', () => {
+      let model: Model = bookshelf.Model.forge<any>({id: 5, attr: 'value'});
+      (model as any).relations['related-model'] = bookshelf.Model.forge<any>({id: 10, attr2: 'value2'});
+
+      let result: any = mapper.map(model, 'model');
+
+      let related = result.data.relationships['related-model'];
+
+      expect(related.data.id).toBe('10');
+      expect(typeof related.data.id).toBe('string');
+
+    });
+
+  });
 });
 
 describe('Bookshelf links', () => {

--- a/src/bookshelf/utils.ts
+++ b/src/bookshelf/utils.ts
@@ -24,7 +24,9 @@ import {
   merge,
   omit,
   reduce,
-  some
+  some,
+  toString,
+  update
 } from 'lodash';
 
 import { LinkOpts, RelationOpts } from '../interfaces';
@@ -260,6 +262,8 @@ export function toJSON(data: Data): any {
     if (! has(json, 'id')) {
       json.id = data.id;
     }
+
+    update(json, 'id', toString);
 
     // Loop over model relations to call toJSON recursively on them
     forOwn(data.relations, function (relData: Data, relName: string): void {


### PR DESCRIPTION
As stated in http://jsonapi.org/format/#document-resource-object-identification

> Every resource object MUST contain an id member and a type member. **The values of the id and type members MUST be strings**.