### PR TITLE
Fix For Head and Tail When Generating Model Template

### DIFF
--- a/src/bookshelf/utils.ts
+++ b/src/bookshelf/utils.ts
@@ -121,8 +121,8 @@ function sample(data: Data): Sample {
 
     return sampled;
   } else if (isCollection(data)) {
-    const first: Model = data.head();
-    const rest: Model[] = data.tail();
+    const first: Model = data.models[0];
+    const rest: Model[] = data.models.slice(1);
     return reduce(rest, mergeSample, sample(first));
   } else {
     return {} as Sample;


### PR DESCRIPTION
I am getting an issue below with trying to invoke `head()` and `tail()` on a CollectionBase object. To resolve, I had to invoke `.models[0]` and `.models.slice(1)`.

* Bookshelf 1.1.0
* Knex 0.20.10
* Bookshelf-jsonapi-params 1.5.1
* Jsonapi query parser 1.3.1
* Jsonapi mapper 1.0.0-beta.16

```
    TypeError: data.head is not a function
    at sample (/Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/es5/bookshelf/utils.js:70:26)
    at /Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/node_modules/lodash/lodash.js:13379:38
    at /Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/node_modules/lodash/lodash.js:4944:15
    at baseForOwn (/Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/node_modules/lodash/lodash.js:3001:24)
    at Function.mapValues (/Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/node_modules/lodash/lodash.js:13378:7)
    at sample (/Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/es5/bookshelf/utils.js:66:38)
    at Object.processData (/Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/es5/bookshelf/utils.js:17:40)
    at Bookshelf.map (/Users/christophersun/Projects/homevest/servicing-api/node_modules/jsonapi-mapper/es5/bookshelf/index.js:36:32)
    at exports.findById (/Users/christophersun/Projects/homevest/servicing-api/resources/users/handlers-v2-admin.js:22:145)
```